### PR TITLE
Do not reset watchdog timer, if we are intentionally resetting if we …

### DIFF
--- a/Prusa-CW-Firmware/main.cpp
+++ b/Prusa-CW-Firmware/main.cpp
@@ -7,6 +7,7 @@
 #include "thermistor.h"
 #include <avr/wdt.h>
 #include <avr/pgmspace.h>
+#include <USBCore.h>
 
 typedef char Serial_num_t[17]; //!< Null terminated string for serial number
 
@@ -46,6 +47,8 @@ enum menu_state {
   CONFIRM,
   ERROR
 };
+
+volatile uint16_t *const bootKeyPtr = (volatile uint16_t *)(RAMEND-1);
 
 String FW_VERSION = "2.0.9";
 
@@ -588,7 +591,11 @@ void lcd_blink(void) {
 }
 
 void loop() {
-  wdt_reset(); 
+
+  if ( *bootKeyPtr != MAGIC_KEY)
+  {
+    wdt_reset();
+  }
   tDown.run();
   tUp.run();
 
@@ -2112,6 +2119,5 @@ void get_key_from_boot(void) ATTR_INIT_SECTION(3);
 //! Refer to the avr-libc manual for more information on the initialization sections.
 void get_key_from_boot(void)
 {
-    volatile uint16_t *const bootKeyPtr = (volatile uint16_t *)(RAMEND-1);
     bootKeyPtrVal = *bootKeyPtr;
 }


### PR DESCRIPTION
…want to go to bootloader.

Fix unable to reset to bootloader.