### PR TITLE
Fix compiler warning int first_position may be used uninitialized in …

### DIFF
--- a/Prusa-CW-Firmware/main.cpp
+++ b/Prusa-CW-Firmware/main.cpp
@@ -250,7 +250,7 @@ static void fan_pwm_control();
 static void fan_heater_rpm();
 static void fan_rpm();
 static void preheat();
-static void lcd_time_print();
+static void lcd_time_print(uint8_t dots_column);
 static void therm1_read();
 static void get_serial_num(Serial_num_t &sn);
 static uint8_t get_reset_flags();
@@ -1966,7 +1966,8 @@ void start_drying() {
       gastro_pan = false;
     }
   }
-  lcd_time_print();
+  if (!preheat_complete) lcd_time_print(8);
+  else lcd_time_print(7);
 }
 
 void start_curing() {
@@ -2026,7 +2027,7 @@ void start_curing() {
       gastro_pan = false;
     }
   }
-  lcd_time_print();
+  lcd_time_print(7);
 }
 
 void start_washing() {
@@ -2072,7 +2073,7 @@ void start_washing() {
           tDown.start();
         }
 
-        lcd_time_print();
+        lcd_time_print(8);
       }
     } else {
       menu_position = 0;
@@ -2140,7 +2141,7 @@ void start_washing() {
           tDown.pause();
         }
 
-        lcd_time_print();
+        lcd_time_print(8);
       }
     } else {
       menu_position = 0;
@@ -2201,7 +2202,11 @@ void stop_curing_drying() {
   menu_move(true);
 }
 
-void lcd_time_print() {
+//! @brief Display remaining time
+//!
+//! @param dots_column Zero indexed column of first line
+//! where to to start printing progress dots.
+void lcd_time_print(uint8_t dots_column) {
   byte mins;
   byte secs;
   if (heat_to_target_temp) {
@@ -2247,25 +2252,8 @@ void lcd_time_print() {
     if (!paused && !paused_time) {
       lcd.setCursor(19, 1);
       lcd.print(" ");
-      int first_position;
 
       if (curing_mode) {
-        if (!drying_mode) {
-          first_position = 7;
-        }
-        if (drying_mode) {
-          if (heat_to_target_temp) {
-            if (!preheat_complete) {
-              first_position = 8;
-            }
-            else {
-              first_position = 7;
-            }
-          }
-          else {
-            first_position = 7;
-          }
-        }
         if (outputchip.digitalRead(COVER_OPEN_PIN) == LOW) {
           if (SI_unit_system) {
             lcd.setCursor(13, 0);
@@ -2286,32 +2274,28 @@ void lcd_time_print() {
         }
       }
 
-      if (!curing_mode) {
-        first_position = 8;
-      }
-
       if (running_count == 0) {
-        lcd.setCursor(first_position, 0);
+        lcd.setCursor(dots_column, 0);
         lcd.print(" ");
-        lcd.setCursor(first_position + 1, 0);
+        lcd.setCursor(dots_column + 1, 0);
         lcd.print(" ");
-        lcd.setCursor(first_position + 2, 0);
+        lcd.setCursor(dots_column + 2, 0);
         lcd.print(" ");
       }
       if (running_count == 1) {
-        lcd.setCursor(first_position, 0);
+        lcd.setCursor(dots_column, 0);
         lcd.print(".");
-        lcd.setCursor(first_position + 1, 0);
+        lcd.setCursor(dots_column + 1, 0);
         lcd.print(" ");
-        lcd.setCursor(first_position + 2, 0);
+        lcd.setCursor(dots_column + 2, 0);
         lcd.print(" ");
       }
       if (running_count == 2) {
-        lcd.setCursor(first_position, 0);
+        lcd.setCursor(dots_column, 0);
         lcd.print(".");
-        lcd.setCursor(first_position + 1, 0);
+        lcd.setCursor(dots_column + 1, 0);
         lcd.print(".");
-        lcd.setCursor(first_position + 2, 0);
+        lcd.setCursor(dots_column + 2, 0);
         lcd.print(" ");
         lcd.setCursor(14, 2);
         lcd.print("  ");
@@ -2319,11 +2303,11 @@ void lcd_time_print() {
         lcd.print("  ");
       }
       if (running_count == 3) {
-        lcd.setCursor(first_position, 0);
+        lcd.setCursor(dots_column, 0);
         lcd.print(".");
-        lcd.setCursor(first_position + 1, 0);
+        lcd.setCursor(dots_column + 1, 0);
         lcd.print(".");
-        lcd.setCursor(first_position + 2, 0);
+        lcd.setCursor(dots_column + 2, 0);
         lcd.print(".");
       }
 


### PR DESCRIPTION
…lcd_time_print().

Convert internal variable first_position deduced from global state to lcd_time_print() parameter dots_column.