### PR TITLE
Use SerialUSB macro to make it more clear, which serial line is meant.

### DIFF
--- a/Prusa-CW-Firmware/main.cpp
+++ b/Prusa-CW-Firmware/main.cpp
@@ -429,7 +429,7 @@ void motor_configuration() {
 
 void setup() {
 
-  //Serial.begin(115200);
+  //SerialUSB.begin(115200);
   outputchip.begin();
   outputchip.pinMode(0B0000000010010111);
   outputchip.pullupMode(0B0000000010000011);


### PR DESCRIPTION
This is no functional change, as SerialUSB is defined as Serial.